### PR TITLE
metaデータをlambdaで設定するようにしたため、メタデータを取得して縦横比を確認するように修正

### DIFF
--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -9,6 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0.2",
+        "aws/aws-sdk-php": "^3.293",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.0",
         "laravel/sanctum": "^3.2",

--- a/laravel/composer.lock
+++ b/laravel/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d091fb37bc7ef0770f7518c4abf334ef",
+    "content-hash": "951070b1723c8fc79926bb74502b889b",
     "packages": [
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
https://github.com/Takapon0407/docker-laravel/issues/54

上記issueへの対応。
S3PUT時に、ファイルの画像から縦横の解像度を取得し、S3のメタデータとして保存をするようにした。
そのため、PHP側では処理に時間がかかる縦横比の確認処理を削除し、メタデータを参照して確認するように修正。