### PR TITLE
localでviteのビルドが反映されない問題を解決

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   app:
     container_name: app
     build: .
+    volumes:
+      - ./laravel:/var/www/laravel
   nginx:
     image: nginx
     container_name: nginx

--- a/laravel/package-lock.json
+++ b/laravel/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "laravel",
             "dependencies": {
                 "bootstrap": "^5.3.1",
                 "glob": "^10.3.4",


### PR DESCRIPTION
localにて、viteのビルドが反映されず、毎回css書き換え後、dockerのビルドを再起動しないとうまくいかなかった。

原因としてはappコンテナがマウントされておらず、viteの更新がコンテナ内で反映されず、うまくいっていなかったっぽい。

変更した際、localにてstorageへアクセスできないエラーが発生したが、


```
The stream or file "/var/www/laravel/storage/logs/laravel.log" could not be opened in append mode: Failed to open stream: Permission denied The exception occurred while attempting to log: The stream or file "/var/www/laravel/storage/logs/laravel.log" could not be opened in append mode: Failed to open stream:
```

以下で解決。
```
chmod -R 777 laravel/storage
chmod -R 777 laravel/bootstrap/cache
```

(あくまでlocalの権限書き換えで、デプロイ後docker起動時に適切な設定をしていれば問題はないはず...）

問題ないとは思うが、本番でも再現するかもなので、一旦上げて様子をみたい。