### PR TITLE
Route53でポートを指定できなかったため、8000ではなく、デフォルトの80でアクセスできるように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ npm install
 $ npm run dev
 ```
 
-`http://localhost:8000/react/home`へアクセス
+`http://localhost/react/home`へアクセス
 
 ## env ファイルの更新手順について
 
@@ -64,15 +64,15 @@ openssl aes-256-cbc -salt -pbkdf2 -iter 10000 -in .env -out .env.production.enc 
 openssl aes-256-cbc -d -pbkdf2 -iter 10000 -in .env.production.enc -out .env.production -k <ENCRYPTION_SECRET>
 ```
 
-
 ## 画像の追加について
 
 画像追加時の基本フローは一旦は以下の通り。
-adobe light room classicにて、下記設定で画像書き出し。
-- 1280 × 853で書き出し。（縦構図は逆）
-- Maxは150KB
+adobe light room classic にて、下記設定で画像書き出し。
 
-上記の形で書き出したファイル群をS3へPUT。
-PUT後、lambdaでメタデータに解像度が付加されるので、あとは本番の画面等で問題なく表示されていることを確認。
+- 1280 × 853 で書き出し。（縦構図は逆）
+- Max は 150KB
+
+上記の形で書き出したファイル群を S3 へ PUT。
+PUT 後、lambda でメタデータに解像度が付加されるので、あとは本番の画面等で問題なく表示されていることを確認。
 
 ※後々ファイル追加もフロント経由でできるといいかも（ただし、認証等入れる必要も出てきてそこまでする？感はあるので、いったんは別の見せ物優先で）

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: nginx
     container_name: nginx
     ports:
-      - 8000:80
+      - 80:80
     volumes:
       - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
       - ./laravel:/var/www/laravel


### PR DESCRIPTION
Route53でドメインを設定しようとしたら、ポート番号が異なるためアクセスできず、他で対応より、アプリケーション側での受け口を修正した方が楽そうなので、変更