### PR TITLE
デプロイ後にdocker image pruneを実行しディスク節約

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,3 +59,4 @@ jobs:
             openssl aes-256-cbc -d -pbkdf2 -iter 10000 -in .env.production.enc -out .env -k ${{ secrets.ENCRYPTION_SECRET }}
             cd /home/ec2-user/tektektech
             docker-compose up -d --build
+            docker image prune -f


### PR DESCRIPTION
issue : https://github.com/Takapon0407/docker-laravel/issues/90

docker-compose buildで古いイメージが蓄積する問題を防ぐため、
デプロイ後にdanglingイメージを自動削除するよう設定。